### PR TITLE
【nova-lxd】将network的physical模式换成bridged模式。修改driver.py

### DIFF
--- a/nova_lxd/nova/virt/lxd/flavor.py
+++ b/nova_lxd/nova/virt/lxd/flavor.py
@@ -106,13 +106,9 @@ def _network(instance, _, network_info, __):
         # key = devname
         key = str(cfg['bridge'])
         devices[key] = {
-            # 'nictype': 'physical',
-            # 'hwaddr': str(cfg['mac_address']),
-            # 'parent': key,    # vif.LXDGenericDriver().get_vif_devname(vifaddr).replace('tap', 'tin'),
-            # 'type': 'nic'
             'nictype': 'bridged',
-            'hwaddr': 'fe:2b:8c:32:33:8b',
-            'parent': 'lxdbr0',  # vif.LXDGenericDriver().get_vif_devname(vifaddr).replace('tap', 'tin'),
+            'hwaddr': str(cfg['mac_address']),
+            'parent': key,    # vif.LXDGenericDriver().get_vif_devname(vifaddr).replace('tap', 'tin'),
             'type': 'nic'
         }
         host_device = vif.LXDGenericDriver().get_vif_devname(vifaddr)


### PR DESCRIPTION
nictype'为'physical'时创建nova instance时会出现如下错误
Failed to set LXC config: lxc.network.0.veth.pair=tap2fd737c2-ai
先修改nictype为bridged